### PR TITLE
[MOD] Explicit null check for resource paths in ResourceServlet

### DIFF
--- a/web/src/main/java/de/betterform/agent/web/resources/ResourceServlet.java
+++ b/web/src/main/java/de/betterform/agent/web/resources/ResourceServlet.java
@@ -68,7 +68,8 @@ public class ResourceServlet extends HttpServlet {
             }
         }
 
-        if (new File(config.getServletContext().getRealPath("WEB-INF/classes/META-INF/resources")).exists()) {
+        final String path = config.getServletContext().getRealPath("WEB-INF/classes/META-INF/resources");
+        if ((path != null) && new File(path).exists()) {
             exploded = true;
         }
 


### PR DESCRIPTION
As checking for the RealPath led to a null pointer exception in our usecase (using betterform.war as a maven
dependency).
The fixed code will not create a `new File(null)`.

It should not break anything with your existing implementation.

The same behaviour possibly applies to the current 5.0 branch.
